### PR TITLE
Opt out of the Block Editor for resources

### DIFF
--- a/includes/functions/core.php
+++ b/includes/functions/core.php
@@ -28,6 +28,7 @@ function setup() {
 	add_action( 'init', $n( 'topic_init' ) );
 	add_action( 'init', $n( 'goal_init' ) );
 	add_action( 'init', $n( 'format_init' ) );
+	add_filter( 'use_block_editor_for_post_type', $n( 'supports_block_editor' ), 10, 2 );
 
 	add_action( 'wp_enqueue_scripts', $n( 'scripts' ) );
 	add_action( 'wp_enqueue_scripts', $n( 'styles' ) );
@@ -82,7 +83,7 @@ function resource_init() {
 					'title'    => __( 'Format', 'learning-commons-framework' ),
 					'taxonomy' => 'lc_format',
 				],
-				'topic'    => [
+				'topic'     => [
 					'title'    => __( 'Topics', 'learning-commons-framework' ),
 					'taxonomy' => 'lc_topic',
 				],
@@ -772,4 +773,20 @@ function script_loader_tag( $tag, $handle ) {
 	}
 
 	return $tag;
+}
+
+/**
+ * Determine which post types support the Block Editor.
+ *
+ * @param bool   $use_block_editor Whether or not hte block editor should be used.
+ * @param string $post_type The current post type.
+ *
+ * @return bool
+ */
+function supports_block_editor( $use_block_editor, $post_type ) {
+	if ( 'lc_resource' === $post_type ) {
+		return false;
+	}
+
+	return $use_block_editor;
 }

--- a/wp-dependencies.json
+++ b/wp-dependencies.json
@@ -1,12 +1,5 @@
 [
   {
-    "name": "Classic Editor",
-    "host": "wordpress",
-    "slug": "classic-editor/classic-editor.php",
-    "uri": "https://wordpress.org/plugins/classic-editor/",
-    "optional": false
-  },
-  {
     "name": "Disable Blog",
     "host": "wordpress",
     "slug": "disable-blog/disable-blog.php",


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

This PR removes Block Editor support for the Resource post type.

## Steps to test

1. Edit a resource.

**Expected behavior:** The Classic Editor is used.

## Additional information

See: https://make.wordpress.org/core/2018/10/30/block-editor-filters/

## Related issues

Not applicable.
