### PR TITLE
feat: add favorites to metadata

### DIFF
--- a/includes/functions/metadata.php
+++ b/includes/functions/metadata.php
@@ -441,6 +441,28 @@ function resource_data_init() {
 
 	$general_info->add_field(
 		[
+			'name'        => __( 'Favorites', 'coop-library-framework' ),
+			'description' => __( 'The number of times this resource has been favorited.', 'coop-library-framework' ),
+			'id'          => $prefix . 'favorites',
+			'type'        => 'hidden',
+			'default'     => 0,
+			'sanitize_cb' => 'intval',
+		]
+	);
+
+	$general_info->add_field(
+		[
+			'name'        => __( 'Views', 'coop-library-framework' ),
+			'description' => __( 'The number of times this resource has been viewed.', 'coop-library-framework' ),
+			'id'          => $prefix . 'views',
+			'type'        => 'hidden',
+			'default'     => 0,
+			'sanitize_cb' => 'intval',
+		]
+	);
+
+	$general_info->add_field(
+		[
 			'name'        => __( 'Link to resource (Required)', 'coop-library-framework' ),
 			'description' => __( 'Web address to access the resource. This information is required.', 'coop-library-framework' ),
 			'id'          => $prefix . 'permanent_link',

--- a/includes/functions/metadata.php
+++ b/includes/functions/metadata.php
@@ -344,17 +344,6 @@ function register_meta() {
 
 	register_post_meta(
 		'lc_resource',
-		'lc_resource_views',
-		[
-			'type'         => 'integer',
-			'description'  => 'The number of times this resource has been viewed.',
-			'single'       => true,
-			'show_in_rest' => true,
-		]
-	);
-
-	register_post_meta(
-		'lc_resource',
 		'lc_resource_favorites',
 		[
 			'type'         => 'integer',
@@ -444,17 +433,6 @@ function resource_data_init() {
 			'name'        => __( 'Favorites', 'coop-library-framework' ),
 			'description' => __( 'The number of times this resource has been favorited.', 'coop-library-framework' ),
 			'id'          => $prefix . 'favorites',
-			'type'        => 'hidden',
-			'default'     => 0,
-			'sanitize_cb' => 'intval',
-		]
-	);
-
-	$general_info->add_field(
-		[
-			'name'        => __( 'Views', 'coop-library-framework' ),
-			'description' => __( 'The number of times this resource has been viewed.', 'coop-library-framework' ),
-			'id'          => $prefix . 'views',
 			'type'        => 'hidden',
 			'default'     => 0,
 			'sanitize_cb' => 'intval',

--- a/includes/functions/metadata.php
+++ b/includes/functions/metadata.php
@@ -341,6 +341,28 @@ function register_meta() {
 			'show_in_rest' => true,
 		]
 	);
+
+	register_post_meta(
+		'lc_resource',
+		'lc_resource_views',
+		[
+			'type'         => 'integer',
+			'description'  => 'The number of times this resource has been viewed.',
+			'single'       => true,
+			'show_in_rest' => true,
+		]
+	);
+
+	register_post_meta(
+		'lc_resource',
+		'lc_resource_favorites',
+		[
+			'type'         => 'integer',
+			'description'  => 'The number of times this resource has been favorited.',
+			'single'       => true,
+			'show_in_rest' => true,
+		]
+	);
 }
 
 /**


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

This pull request registers a metadata key and adds a hidden metadata field for favorites.

## Steps to test

1. Create a new resource.
2. Inspect the editor markup, and find hidden input for `lc_resource_favorites`.
3. Using WP-CLI, confirm that the resource has the metadata key for `lc_resource_favorites` set to 0.

## Additional information

Not applicable.

## Related issues

- Blocks https://github.com/platform-coop-toolkit/coop-library/issues/111.
