### PR TITLE
feat: add Koko Analytics for view tracking

### DIFF
--- a/wp-dependencies.json
+++ b/wp-dependencies.json
@@ -14,6 +14,13 @@
     "optional": false
   },
   {
+    "name": "Koko Analytics",
+    "host": "wordpress",
+    "slug": "koko-analytics/koko-analytics.php",
+    "uri": "https://wordpress.org/plugins/koko-analytics/",
+    "optional": false
+  },
+  {
     "name": "Polylang",
     "host": "wordpress",
     "slug": "polylang/polylang.php",


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

[Koko Analytics](https://www.kokoanalytics.com/) is a privacy-focused, locally-hosted analytics plugin for WordPress. This PR adds it as a plugin dependency, and we can use it to track views for resources and sort by views.

## Steps to test

1. Check out this branch.

**Expected behavior:** Koko Analytics is installed and activated.

## Additional information

Not applicable.

## Related issues

Not applicable.
