### PR TITLE
feat: add support for parent goals (fixes #263)

### DIFF
--- a/includes/functions/core.php
+++ b/includes/functions/core.php
@@ -221,7 +221,7 @@ function goal_init() {
 		'lc_goal',
 		array( 'lc_resource' ),
 		array(
-			'hierarchical'          => false,
+			'hierarchical'          => true,
 			'labels'                => array(
 				'name'                       => __( 'Goals', 'coop-library-framework' ),
 				'singular_name'              => __( 'Goal', 'coop-library-framework' ),


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

Adds support for parent/child goals.

## Steps to test

**Expected behavior:** Goals can be assigned parent/child relationships.

## Additional information

Not applicable.

## Related issues

- Fixes #263.
