### PR TITLE
feat: add a setting to indicate whether or not a resource is paywalled

### DIFF
--- a/includes/functions/metadata.php
+++ b/includes/functions/metadata.php
@@ -60,6 +60,17 @@ function register_meta() {
 
 	register_post_meta(
 		'lc_resource',
+		'lc_resource_has_paywall',
+		[
+			'type'         => 'string',
+			'description'  => 'Indicates whether or not the resource is behind a paywall.',
+			'single'       => true,
+			'show_in_rest' => true,
+		]
+	);
+
+	register_post_meta(
+		'lc_resource',
 		'lc_resource_perma_cc_links',
 		[
 			'type'         => 'array',
@@ -451,6 +462,15 @@ function resource_data_init() {
 				'data-validation' => 'true',
 				'data-required'   => 'true',
 			],
+		]
+	);
+
+	$general_info->add_field(
+		[
+			'name'        => __( 'Paywall', 'coop-library-framework' ),
+			'description' => __( 'Is this resource behind a paywall?', 'coop-library-framework' ),
+			'id'          => $prefix . 'has_paywall',
+			'type'        => 'checkbox',
 		]
 	);
 


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

Adds a checkbox to the Resource editor which indicates whether or not the resource is behind a paywall. Does not impact the display of a resource at present.

## Steps to test

Review new field for functionality (data appears in `wp-json/wp/v2/resources` endpoint) and descriptive text/labelling.

## Additional information

Not applicable.

## Related issues

Not applicable.
