### PR TITLE
fix: publication year is optional

### DIFF
--- a/assets/js/admin/admin.js
+++ b/assets/js/admin/admin.js
@@ -14,6 +14,7 @@ jQuery( document ).ready( function( $ ) {
 	const $year = $( '#lc_resource_publication_year' );
 	const $month = $( '#lc_resource_publication_month' );
 	const $day = $( '#lc_resource_publication_day' );
+	const $date = $( '#lc_resource_publication_date' );
 	const $titleRow = $( '#titlewrap' );
 	const $toValidate = $( '[data-validation]' );
 
@@ -69,20 +70,44 @@ jQuery( document ).ready( function( $ ) {
 		}
 	}
 
+	/**
+	 * Update the hidden publicationDate field.
+	 *
+	 * @param {Integer|Boolean} year
+	 * @param {Integer|Boolean} month
+	 * @param {Integer|Boolean} day
+	 */
+	function updatePublicationDate( year, month, day ) {
+		const pieces = [];
+		if ( year ) {
+			pieces.push( year );
+		}
+		if ( month && 2 == month.length  ) {
+			pieces.push( month );
+		}
+		if ( day ) {
+			pieces.push( day );
+		}
+		const publicationDate = 0 < pieces.length ? pieces.join( '-' ) : 'ongoing';
+		$date.val( publicationDate );
+	}
+
 	$year.keyup( ( e ) => {
 		let yearVal = $( e.target ).val();
+		let monthVal = $month.val();
+
 		// Don't validate until we hit four characters.
 		if ( 4 === yearVal.length ) {
 			if ( ! yearVal ) {
 				yearVal = new Date().getFullYear();
 			}
-			let monthVal = $month.val();
 			if ( ! monthVal ) {
 				monthVal = new Date().getMonth();
 
 			}
 			loadDays( yearVal, monthVal, $day );
 		}
+		updatePublicationDate( yearVal, monthVal, false );
 	} );
 
 	$month.change( ( e ) => {
@@ -96,11 +121,19 @@ jQuery( document ).ready( function( $ ) {
 		} else {
 			loadDays( yearVal, monthVal, $day );
 		}
+
+		updatePublicationDate( yearVal, monthVal, false );
 	} );
 
 	$day.change( ( e ) => {
+		const yearVal = $year.val();
+		const monthVal = $month.val();
+		const dayVal = $( e.target ).val();
+
 		$( e.target ).parents( '.cmb-row' ).removeClass( 'form-invalid' );
 		$( e.target ).siblings( '.error' ).remove();
+
+		updatePublicationDate( yearVal, monthVal, dayVal );
 	} );
 
 	if ( !$toValidate.length ) {
@@ -177,9 +210,14 @@ jQuery( document ).ready( function( $ ) {
 	 * @param {Event} event
 	 */
 	function validateForm( event ) {
+		const yearVal = $year.val();
+		const monthVal = $month.val();
+		const dayVal = $day.val();
 		const $errorFields = [];
 		let $firstError = null;
 		$( '.error' ).remove();
+
+		updatePublicationDate( yearVal, monthVal, dayVal );
 
 		$urlFields.each( ( i, e ) => {
 			if ( $( e ).is( ':visible' ) ) {

--- a/assets/js/admin/admin.js
+++ b/assets/js/admin/admin.js
@@ -114,6 +114,7 @@ jQuery( document ).ready( function( $ ) {
 		let yearVal = $year.val();
 		if ( ! yearVal ) {
 			yearVal = new Date().getFullYear();
+			$year.val( yearVal );
 		}
 		const monthVal = $( e.target ).val();
 		if ( ! monthVal ) {

--- a/includes/functions/metadata.php
+++ b/includes/functions/metadata.php
@@ -21,8 +21,6 @@ function setup() {
 
 	add_action( 'init', $n( 'register_meta' ) );
 	add_action( 'cmb2_admin_init', $n( 'resource_data_init' ) );
-	add_action( 'save_post_lc_resource', $n( 'update_publication_date' ), 10, 2 );
-	add_action( 'edit_post_lc_resource', $n( 'update_publication_date' ), 10, 2 );
 }
 
 /**
@@ -518,21 +516,28 @@ function resource_data_init() {
 		[
 			'name' => 'Publication date',
 			'type' => 'title',
-			'id'   => $prefix . 'publication_date',
+			'id'   => $prefix . 'publication_date_title',
 		]
 	);
 
 	$general_info->add_field(
 		[
-			'name'        => __( 'Publication year (Required)', 'coop-library-framework' ),
-			'description' => __( 'The year the resource was published. This information is required.', 'coop-library-framework' ),
+			'name'    => 'Publication date',
+			'type'    => 'hidden',
+			'id'      => $prefix . 'publication_date',
+			'default' => 'ongoing',
+		]
+	);
+
+	$general_info->add_field(
+		[
+			'name'        => __( 'Publication year', 'coop-library-framework' ),
+			'description' => __( 'The year the resource was published.', 'coop-library-framework' ),
 			'id'          => $prefix . 'publication_year',
 			'type'        => 'text',
-			'classes'     => 'cmb-required',
 			'attributes'  => [
 				'data-validation' => 'true',
 				'data-datetime'   => 'year',
-				'data-required'   => 'true',
 			],
 		]
 	);
@@ -814,35 +819,4 @@ function preload_day_options( $year, $month ) {
 	}
 
 	return $options;
-}
-
-/**
- * Update the publication date when year, month, or day are modified.
- *
- * @param int      $post_id The post ID.
- * @param \WP_Post $post The post object.
- */
-function update_publication_date( $post_id, $post ) {
-	if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
-		return;
-	}
-
-	$cmb = cmb2_get_metabox( 'resource_data', $post_id );
-
-	if ( ! $cmb || ! isset( $_POST[ $cmb->nonce() ] ) || ! wp_verify_nonce( $_POST[ $cmb->nonce() ], $cmb->nonce() ) ) {
-		return;
-	}
-
-	$y      = $_REQUEST['lc_resource_publication_year'];
-	$m      = $_REQUEST['lc_resource_publication_month'];
-	$d      = $_REQUEST['lc_resource_publication_day'];
-	$pieces = [];
-	foreach ( [ $y, $m, $d ] as $piece ) {
-		if ( $piece ) {
-			$pieces[] = $piece;
-		}
-	}
-	$date = implode( '-', $pieces );
-
-	update_post_meta( $post_id, 'lc_resource_publication_date', $date );
 }


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

Publication dates are now optional.

This PR makes the following changes:

1. Publication year is now an optional field.
2. Whenever publication year, month, or day fields are modified, the hidden `lc_resource_publication_date` field is updated to a string in the format `YYYY(-MM-DD)` OR the string `ongoing` if year, month, and day are unset.

## Steps to test

1. While editing a resource, inspect the page and find the hidden `lc_resource_publication_date` field.
2. Modify the year, month, and day and observe the field's value updating.

**Expected behavior:** The publication date field updates in sync with changes to year, month, and day.

## Additional information

Not applicable.

## Related issues

Not applicable.
