### PR TITLE
feat: add term order field (resolves #294)

### DIFF
--- a/includes/functions/core.php
+++ b/includes/functions/core.php
@@ -794,9 +794,7 @@ function get_terms_orderby( $orderby = 'name', $args = array() ) {
 		return $orderby;
 	}
 
-	if ( empty( $args['orderby'] ) || empty( $orderby ) || in_array( $orderby, array( 'name', 't.name' ), true ) ) {
-		$orderby = 'tt.name, tt.order';
-	} elseif ( 'order' === $args['orderby'] ) {
+	if ( empty( $args['orderby'] ) || empty( $orderby ) || 'order' === $args['orderby'] ) {
 		$orderby = 'tt.order, t.name';
 	}
 

--- a/includes/functions/core.php
+++ b/includes/functions/core.php
@@ -47,6 +47,7 @@ function setup() {
 	add_filter( 'pll_get_taxonomies', $n( 'add_topic_to_pll' ), 10, 2 );
 	add_filter( 'pll_get_taxonomies', $n( 'add_goal_to_pll' ), 10, 2 );
 	add_filter( 'pll_get_taxonomies', $n( 'add_format_to_pll' ), 10, 2 );
+	add_filter( 'wp_fancy_term_order', '__return_false' );
 
 	do_action( 'coop_library_framework_loaded' );
 }

--- a/includes/functions/core.php
+++ b/includes/functions/core.php
@@ -52,7 +52,7 @@ function setup() {
 	add_filter( 'wp_fancy_term_order', '__return_false' );
 
 	// Fix for https://github.com/stuttter/wp-term-order/issues/11.
-	add_filter( 'get_terms_orderby', $n( 'get_terms_orderby' ), 9, 2 );
+	add_filter( 'get_terms_orderby', $n( 'get_terms_orderby' ), 11, 2 );
 
 	do_action( 'coop_library_framework_loaded' );
 }
@@ -790,15 +790,13 @@ function supports_block_editor( $use_block_editor, $post_type ) {
  * @return string $orderby The (possible modified) `orderby` value.
  */
 function get_terms_orderby( $orderby = 'name', $args = array() ) {
-
-	// Do not override if being manually controlled
 	if ( ! empty( $_GET['orderby'] ) && ! empty( $_GET['taxonomy'] ) ) { // @codingStandardsIgnoreLine
 		return $orderby;
 	}
 
-	if ( empty( $args['orderby'] ) || empty( $orderby ) || ( 'order' === $args['orderby'] ) ) {
-		$orderby = 'tt.order';
-	} elseif ( 't.name' === $orderby ) {
+	if ( empty( $args['orderby'] ) || empty( $orderby ) || in_array( $orderby, array( 'name', 't.name' ), true ) ) {
+		$orderby = 'tt.name, tt.order';
+	} elseif ( 'order' === $args['orderby'] ) {
 		$orderby = 'tt.order, t.name';
 	}
 

--- a/includes/functions/core.php
+++ b/includes/functions/core.php
@@ -51,9 +51,6 @@ function setup() {
 	// Disable inaccessible sortable JavaScript for term order.
 	add_filter( 'wp_fancy_term_order', '__return_false' );
 
-	// Fix for https://github.com/stuttter/wp-term-order/issues/11.
-	add_filter( 'get_terms_orderby', $n( 'get_terms_orderby' ), 11, 2 );
-
 	do_action( 'coop_library_framework_loaded' );
 }
 
@@ -780,23 +777,4 @@ function supports_block_editor( $use_block_editor, $post_type ) {
 	}
 
 	return $use_block_editor;
-}
-
-/**
- * Force `orderby` to `tt.order` if not explicitly set to something else.
- *
- * @param  string $orderby The `orderby` value.
- * @param  array  $args Arguments.
- * @return string $orderby The (possible modified) `orderby` value.
- */
-function get_terms_orderby( $orderby = 'name', $args = array() ) {
-	if ( ! empty( $_GET['orderby'] ) && ! empty( $_GET['taxonomy'] ) ) { // @codingStandardsIgnoreLine
-		return $orderby;
-	}
-
-	if ( empty( $args['orderby'] ) || empty( $orderby ) || 'order' === $args['orderby'] ) {
-		$orderby = 'tt.order, t.name';
-	}
-
-	return $orderby;
 }

--- a/includes/functions/core.php
+++ b/includes/functions/core.php
@@ -47,7 +47,12 @@ function setup() {
 	add_filter( 'pll_get_taxonomies', $n( 'add_topic_to_pll' ), 10, 2 );
 	add_filter( 'pll_get_taxonomies', $n( 'add_goal_to_pll' ), 10, 2 );
 	add_filter( 'pll_get_taxonomies', $n( 'add_format_to_pll' ), 10, 2 );
+
+	// Disable inaccessible sortable JavaScript for term order.
 	add_filter( 'wp_fancy_term_order', '__return_false' );
+
+	// Fix for https://github.com/stuttter/wp-term-order/issues/11.
+	add_filter( 'get_terms_orderby', $n( 'get_terms_orderby' ), 9, 2 );
 
 	do_action( 'coop_library_framework_loaded' );
 }
@@ -775,4 +780,27 @@ function supports_block_editor( $use_block_editor, $post_type ) {
 	}
 
 	return $use_block_editor;
+}
+
+/**
+ * Force `orderby` to `tt.order` if not explicitly set to something else.
+ *
+ * @param  string $orderby The `orderby` value.
+ * @param  array  $args Arguments.
+ * @return string $orderby The (possible modified) `orderby` value.
+ */
+function get_terms_orderby( $orderby = 'name', $args = array() ) {
+
+	// Do not override if being manually controlled
+	if ( ! empty( $_GET['orderby'] ) && ! empty( $_GET['taxonomy'] ) ) { // @codingStandardsIgnoreLine
+		return $orderby;
+	}
+
+	if ( empty( $args['orderby'] ) || empty( $orderby ) || ( 'order' === $args['orderby'] ) ) {
+		$orderby = 'tt.order';
+	} elseif ( 't.name' === $orderby ) {
+		$orderby = 'tt.order, t.name';
+	}
+
+	return $orderby;
 }

--- a/includes/functions/metadata.php
+++ b/includes/functions/metadata.php
@@ -362,18 +362,6 @@ function register_meta() {
 function resource_data_init() {
 	$prefix = 'lc_resource_';
 
-	$term_info = new_cmb2_box(
-		[
-			'id'           => 'term_info',
-			'title'        => __( 'Tag Information', 'coop-library-framework' ),
-			'object_types' => [ 'term' ],
-			'taxonomies'   => [ 'lc_goal', 'lc_topic' ],
-			'context'      => 'normal',
-			'priority'     => 'high',
-			'show_names'   => true,
-		]
-	);
-
 	$general_info = new_cmb2_box(
 		[
 			'id'           => '01_general_info',
@@ -437,17 +425,6 @@ function resource_data_init() {
 			'context'      => 'normal',
 			'priority'     => 'high',
 			'show_names'   => true,
-		]
-	);
-
-	$term_info->add_field(
-		[
-			'name'        => __( 'Order', 'coop-library-framework' ),
-			'description' => __( 'The numeric order of this tag.', 'coop-library-framework' ),
-			'id'          => 'lc_term_order',
-			'type'        => 'text',
-			'default'     => 0,
-			'sanitize_cb' => 'intval',
 		]
 	);
 

--- a/includes/functions/metadata.php
+++ b/includes/functions/metadata.php
@@ -362,9 +362,21 @@ function register_meta() {
 function resource_data_init() {
 	$prefix = 'lc_resource_';
 
+	$term_info = new_cmb2_box(
+		[
+			'id'           => 'term_info',
+			'title'        => __( 'Tag Information', 'coop-library-framework' ),
+			'object_types' => [ 'term' ],
+			'taxonomies'   => [ 'lc_goal', 'lc_topic' ],
+			'context'      => 'normal',
+			'priority'     => 'high',
+			'show_names'   => true,
+		]
+	);
+
 	$general_info = new_cmb2_box(
 		[
-			'id'           => '01_resource_data',
+			'id'           => '01_general_info',
 			'title'        => __( 'General Information', 'coop-library-framework' ),
 			'object_types' => [ 'lc_resource' ],
 			'context'      => 'normal',
@@ -425,6 +437,17 @@ function resource_data_init() {
 			'context'      => 'normal',
 			'priority'     => 'high',
 			'show_names'   => true,
+		]
+	);
+
+	$term_info->add_field(
+		[
+			'name'        => __( 'Order', 'coop-library-framework' ),
+			'description' => __( 'The numeric order of this tag.', 'coop-library-framework' ),
+			'id'          => 'lc_term_order',
+			'type'        => 'text',
+			'default'     => 0,
+			'sanitize_cb' => 'intval',
 		]
 	);
 

--- a/wp-dependencies.json
+++ b/wp-dependencies.json
@@ -33,5 +33,12 @@
     "slug": "theme-translation-for-polylang/polylang-theme-translation.php",
     "uri": "https://wordpress.org/plugins/theme-translation-for-polylang/",
     "optional": false
+  },
+  {
+    "name": "WP Term Order",
+    "host": "wordpress",
+    "slug": "wp-term-order/wp-term-order.php",
+    "uri": "https://wordpress.org/plugins/wp-term-order/",
+    "optional": false
   }
 ]

--- a/wp-dependencies.json
+++ b/wp-dependencies.json
@@ -36,9 +36,9 @@
   },
   {
     "name": "WP Term Order",
-    "host": "wordpress",
+    "host": "github",
     "slug": "wp-term-order/wp-term-order.php",
-    "uri": "https://wordpress.org/plugins/wp-term-order/",
+    "uri": "platform-coop-toolkit/wp-term-order",
     "optional": false
   }
 ]


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

Adds a custom meta field to topics and goals which allows a numeric order to be assigned.

## Steps to test

1. Edit a topic or goal.

**Expected behavior:** Order can be customized.

## Additional information

Front-end implementation will be completed in https://github.com/platform-coop-toolkit/coop-library/issues/168.

## Related issues

- Resolves #294.
