### PR TITLE
feat: store language in metadata

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -1,9 +1,21 @@
-# Convert Metadata from Custom Metaboxes 2 to Advanced Custom Fields
+# Conversion Scripts
+
+## Convert Metadata from Custom Metaboxes 2 to Advanced Custom Fields
 
 To convert your resource library's metadata from Custom Metaboxes 2 to Advanced Custom Fields, run the following command from the WordPress root using [wp-cli](https://wp-cli.org):
 
 ```bash
-wp eval-file wp-content/plugins/coop-library-framework/bin/convert-meta.php`
+wp eval-file wp-content/plugins/coop-library-framework/bin/convert-meta.php
 ```
 
 In order to see the updated metadata on the resource library front-end, you'll need to update to the [1.0.0-alpha.2](https://github.com/platform-coop-toolkit/coop-library/milestones/1.0.0-alpha.2) version of the Co-op Library theme.
+
+## Convert Resource Language from Polylang to Advanced Custom Fields
+
+To convert your resources' language from a Polylang language to a metadata field managed through Advanced Custom Fields, run the following command from the WordPress root using [wp-cli](https://wp-cli.org):
+
+```bash
+wp eval-file wp-content/plugins/coop-library-framework/bin/convert-language.php
+```
+
+In order to see the updated language on the resource library front-end, you'll need to update to the [1.0.0-alpha.2](https://github.com/platform-coop-toolkit/coop-library/milestones/1.0.0-alpha.2) version of the Co-op Library theme.

--- a/bin/convert-language.php
+++ b/bin/convert-language.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Convert languages from Polylang taxonomy to new (1.0.0-alpha.3) format.
+ *
+ * @package CoopLibraryFramework
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+$resources = get_posts(
+	[
+		'fields'         => 'ids',
+		'posts_per_page' => -1,
+		'post_type'      => 'lc_resource',
+		'post_status'    => 'all',
+		'lang'           => '',
+	]
+);
+
+foreach ( $resources as $post_id ) {
+	update_post_meta( $post_id, 'language', pll_get_post_language( $post_id ) );
+	update_post_meta( $post_id, '_language', 'field_5e62c939ddcb6' );
+}

--- a/includes/functions/core.php
+++ b/includes/functions/core.php
@@ -42,7 +42,7 @@ function setup() {
 	// Hook to allow async or defer on asset loading.
 	add_filter( 'script_loader_tag', $n( 'script_loader_tag' ), 10, 2 );
 	// Ensure resources and topics are translatable.
-	add_filter( 'pll_get_post_types', $n( 'add_resource_to_pll' ), 10, 2 );
+	add_filter( 'pll_get_post_types', $n( 'add_resource_to_pll' ), 10, 2 ); // TODO: Remove this.
 	add_filter( 'pll_get_taxonomies', $n( 'add_coop_type_to_pll' ), 10, 2 );
 	add_filter( 'pll_get_taxonomies', $n( 'add_sector_to_pll' ), 10, 2 );
 	add_filter( 'pll_get_taxonomies', $n( 'add_region_to_pll' ), 10, 2 );

--- a/includes/functions/core.php
+++ b/includes/functions/core.php
@@ -9,6 +9,8 @@ namespace CoopLibraryFramework\Core;
 
 use \WP_Error as WP_Error;
 
+use function CoopLibraryFramework\Internationalization\get_localized_language;
+
 /**
  * Default setup routine
  *
@@ -70,7 +72,10 @@ function resource_init() {
 				'title',
 				'language'  => [
 					'title'    => __( 'Language', 'coop-library-framework' ),
-					'taxonomy' => 'language',
+					'meta_key' => 'language',
+					'function' => function() {
+						echo get_localized_language( get_post_meta( get_the_ID(), 'language', true ) );
+					},
 				],
 				'format'    => [
 					'title'    => __( 'Format', 'coop-library-framework' ),
@@ -87,6 +92,7 @@ function resource_init() {
 				'added'     => [
 					'title'      => __( 'Date Added', 'coop-library-framework' ),
 					'post_field' => 'post_date',
+					'default'    => 'DESC',
 				],
 			],
 			'labels'              => [

--- a/includes/functions/core.php
+++ b/includes/functions/core.php
@@ -665,7 +665,7 @@ function admin_scripts() {
 	wp_enqueue_script(
 		'coop_library_framework_admin',
 		script_url( 'admin', 'admin' ),
-		[ 'wp-i18n' ],
+		[ 'wp-a11y', 'wp-i18n' ],
 		COOP_LIBRARY_FRAMEWORK_VERSION,
 		true
 	);

--- a/includes/functions/core.php
+++ b/includes/functions/core.php
@@ -74,7 +74,7 @@ function resource_init() {
 					'title'    => __( 'Language', 'coop-library-framework' ),
 					'meta_key' => 'language',
 					'function' => function() {
-						echo get_localized_language( get_post_meta( get_the_ID(), 'language', true ) );
+						echo esc_attr( get_localized_language( get_post_meta( get_the_ID(), 'language', true ) ) );
 					},
 				],
 				'format'    => [

--- a/includes/functions/core.php
+++ b/includes/functions/core.php
@@ -41,6 +41,14 @@ function setup() {
 	add_filter( 'mce_css', $n( 'mce_css' ) );
 	// Hook to allow async or defer on asset loading.
 	add_filter( 'script_loader_tag', $n( 'script_loader_tag' ), 10, 2 );
+	// Ensure resources and topics are translatable.
+	add_filter( 'pll_get_post_types', $n( 'add_resource_to_pll' ), 10, 2 );
+	add_filter( 'pll_get_taxonomies', $n( 'add_coop_type_to_pll' ), 10, 2 );
+	add_filter( 'pll_get_taxonomies', $n( 'add_sector_to_pll' ), 10, 2 );
+	add_filter( 'pll_get_taxonomies', $n( 'add_region_to_pll' ), 10, 2 );
+	add_filter( 'pll_get_taxonomies', $n( 'add_topic_to_pll' ), 10, 2 );
+	add_filter( 'pll_get_taxonomies', $n( 'add_goal_to_pll' ), 10, 2 );
+	add_filter( 'pll_get_taxonomies', $n( 'add_format_to_pll' ), 10, 2 );
 
 	// Disable inaccessible sortable JavaScript for term order.
 	add_filter( 'wp_fancy_term_order', '__return_false' );
@@ -136,6 +144,23 @@ function resource_init() {
 }
 
 /**
+ * Add the `lc_resource` post type to Polylang, ensuring it is translatable.
+ *
+ * @param array $post_types An array of post types.
+ * @param bool  $is_settings Whether or not we are on the settings page.
+ *
+ * @return array
+ */
+function add_resource_to_pll( $post_types, $is_settings ) {
+	if ( $is_settings ) {
+		unset( $post_types['lc_resource'] );
+	} else {
+		$post_types['lc_resource'] = 'lc_resource';
+	}
+	return $post_types;
+}
+
+/**
  * Registers the `lc_topic` taxonomy,
  * for use with 'lc_resource'.
  */
@@ -181,6 +206,23 @@ function topic_init() {
 			'slug'     => 'topics',
 		)
 	);
+}
+
+/**
+ * Add the `lc_topic` taxonomy to Polylang, ensuring it is translatable.
+ *
+ * @param array $taxonomies An array of taxonomies.
+ * @param bool  $is_settings Whether or not we are on the settings page.
+ *
+ * @return array
+ */
+function add_topic_to_pll( $taxonomies, $is_settings ) {
+	if ( $is_settings ) {
+		unset( $taxonomies['lc_topic'] );
+	} else {
+		$taxonomies['lc_topic'] = 'lc_topic';
+	}
+	return $taxonomies;
 }
 
 /**
@@ -232,6 +274,24 @@ function goal_init() {
 }
 
 /**
+ * Add the `lc_goal` taxonomy to Polylang, ensuring it is translatable.
+ *
+ * @param array $taxonomies An array of taxonomies.
+ * @param bool  $is_settings Whether or not we are on the settings page.
+ *
+ * @return array
+ */
+function add_goal_to_pll( $taxonomies, $is_settings ) {
+	if ( $is_settings ) {
+		unset( $taxonomies['lc_goal'] );
+	} else {
+		$taxonomies['lc_goal'] = 'lc_goal';
+	}
+	return $taxonomies;
+}
+
+
+/**
  * Registers the `lc_region` taxonomy,
  * for use with 'lc_resource'.
  */
@@ -280,6 +340,24 @@ function region_init() {
 }
 
 /**
+ * Add the `lc_region` taxonomy to Polylang, ensuring it is translatable.
+ *
+ * @param array $taxonomies An array of taxonomies.
+ * @param bool  $is_settings Whether or not we are on the settings page.
+ *
+ * @return array
+ */
+function add_region_to_pll( $taxonomies, $is_settings ) {
+	if ( $is_settings ) {
+		unset( $taxonomies['lc_region'] );
+	} else {
+		$taxonomies['lc_region'] = 'lc_region';
+	}
+	return $taxonomies;
+}
+
+
+/**
  * Registers the `lc_sector` taxonomy,
  * for use with 'lc_resource'.
  */
@@ -325,6 +403,23 @@ function sector_init() {
 			'slug'     => 'sectors',
 		)
 	);
+}
+
+/**
+ * Add the `lc_sector` taxonomy to Polylang, ensuring it is translatable.
+ *
+ * @param array $taxonomies An array of taxonomies.
+ * @param bool  $is_settings Whether or not we are on the settings page.
+ *
+ * @return array
+ */
+function add_sector_to_pll( $taxonomies, $is_settings ) {
+	if ( $is_settings ) {
+		unset( $taxonomies['lc_sector'] );
+	} else {
+		$taxonomies['lc_sector'] = 'lc_sector';
+	}
+	return $taxonomies;
 }
 
 /**
@@ -376,6 +471,23 @@ function coop_type_init() {
 }
 
 /**
+ * Add the `lc_coop_type` taxonomy to Polylang, ensuring it is translatable.
+ *
+ * @param array $taxonomies An array of taxonomies.
+ * @param bool  $is_settings Whether or not we are on the settings page.
+ *
+ * @return array
+ */
+function add_coop_type_to_pll( $taxonomies, $is_settings ) {
+	if ( $is_settings ) {
+		unset( $taxonomies['lc_coop_type'] );
+	} else {
+		$taxonomies['lc_coop_type'] = 'lc_coop_type';
+	}
+	return $taxonomies;
+}
+
+/**
  * Registers the `lc_format` taxonomy,
  * for use with 'lc_resource'.
  */
@@ -421,6 +533,23 @@ function format_init() {
 			'slug'     => 'formats',
 		)
 	);
+}
+
+/**
+ * Add the `lc_format` taxonomy to Polylang, ensuring it is translatable.
+ *
+ * @param array $taxonomies An array of taxonomies.
+ * @param bool  $is_settings Whether or not we are on the settings page.
+ *
+ * @return array
+ */
+function add_format_to_pll( $taxonomies, $is_settings ) {
+	if ( $is_settings ) {
+		unset( $taxonomies['lc_format'] );
+	} else {
+		$taxonomies['lc_format'] = 'lc_format';
+	}
+	return $taxonomies;
 }
 
 /**
@@ -536,7 +665,7 @@ function admin_scripts() {
 	wp_enqueue_script(
 		'coop_library_framework_admin',
 		script_url( 'admin', 'admin' ),
-		[ 'wp-a11y', 'wp-i18n' ],
+		[ 'wp-i18n' ],
 		COOP_LIBRARY_FRAMEWORK_VERSION,
 		true
 	);

--- a/includes/functions/internationalization.php
+++ b/includes/functions/internationalization.php
@@ -47,8 +47,11 @@ function copy_post_metas( $metas ) {
  *
  * @return array $countries An associative array of countries.
  */
-function get_country_list( $locale = 'en_US' ) {
-	$countries = include_once COOP_LIBRARY_FRAMEWORK_PATH . 'vendor/umpirsky/country-list/data/' . $locale . '/country.php';
+function get_country_list( $locale = false ) {
+	if ( ! $locale ) {
+		$locale = get_locale();
+	}
+	$countries = include COOP_LIBRARY_FRAMEWORK_PATH . 'vendor/umpirsky/country-list/data/' . $locale . '/country.php';
 	return $countries;
 }
 
@@ -59,23 +62,48 @@ function get_country_list( $locale = 'en_US' ) {
  *
  * @return array $languages An associative array of languages.
  */
-function get_language_list( $locale = 'en_US' ) {
-	$languages = include_once COOP_LIBRARY_FRAMEWORK_PATH . 'vendor/umpirsky/language-list/data/' . $locale . '/language.php';
+function get_language_list( $locale = false ) {
+	if ( ! $locale ) {
+		$locale = get_locale();
+	}
+	$languages = include COOP_LIBRARY_FRAMEWORK_PATH . 'vendor/umpirsky/language-list/data/' . $locale . '/language.php';
 	return $languages;
 }
 
 /**
  * Get language choices for ACF based on what languages are set in Polylang.
  *
+ * @param string $locale The current locale, for example en_US.
+ *
  * @return array $choices
  */
-function get_language_choices() {
+function get_language_choices( $locale = false ) {
+	if ( ! $locale ) {
+		$locale = get_locale();
+	}
 	$locales   = ( function_exists( 'pll_languages_list' ) ) ? pll_languages_list( [ 'fields' => 'slug' ] ) : [ 'en' ];
-	$languages = get_language_list( get_locale() );
+	$languages = get_language_list( $locale );
 	$choices   = [];
 	foreach ( $locales as $key ) {
 		$choices[ $key ] = $languages[ $key ];
 	}
 	asort( $choices );
 	return $choices;
+}
+
+/**
+ * Get language choices for ACF based on what languages are set in Polylang.
+ *
+ * @param string $slug The language slug to look up.
+ * @param string $locale The current locale, for example en_US.
+ *
+ * @return array $choices
+ */
+function get_localized_language( $slug, $locale = false ) {
+	if ( ! $locale ) {
+		$locale = get_locale();
+	}
+	$languages = get_language_list( $locale );
+
+	return $languages[ $slug ];
 }

--- a/includes/functions/internationalization.php
+++ b/includes/functions/internationalization.php
@@ -63,3 +63,19 @@ function get_language_list( $locale = 'en_US' ) {
 	$languages = include_once COOP_LIBRARY_FRAMEWORK_PATH . 'vendor/umpirsky/language-list/data/' . $locale . '/language.php';
 	return $languages;
 }
+
+/**
+ * Get language choices for ACF based on what languages are set in Polylang.
+ *
+ * @return array $choices
+ */
+function get_language_choices() {
+	$locales   = ( function_exists( 'pll_languages_list' ) ) ? pll_languages_list( [ 'fields' => 'slug' ] ) : [ 'en' ];
+	$languages = get_language_list( get_locale() );
+	$choices   = [];
+	foreach ( $locales as $key ) {
+		$choices[ $key ] = $languages[ $key ];
+	}
+	asort( $choices );
+	return $choices;
+}

--- a/includes/functions/metadata.php
+++ b/includes/functions/metadata.php
@@ -14,6 +14,8 @@ use Symfony\Component\Validator\Constraints\Issn;
 use Symfony\Component\Validator\Validation;
 use \WP_Error as WP_Error;
 
+use function CoopLibraryFramework\Internationalization\get_language_choices;
+
 /**
  * Default setup routine
  *
@@ -409,6 +411,28 @@ function register_fields() {
 						),
 						'default_value'     => '',
 						'placeholder'       => '',
+					),
+					array(
+						'key'               => 'field_5e62c939ddcb6',
+						'label'             => __( 'Resource language', 'coop-library-framework' ),
+						'name'              => 'language',
+						'type'              => 'select',
+						'instructions'      => __( 'The language of the resource.', 'coop-library-framework' ),
+						'required'          => 1,
+						'conditional_logic' => 0,
+						'wrapper'           => array(
+							'width' => '',
+							'class' => '',
+							'id'    => '',
+						),
+						'choices'           => get_language_choices(),
+						'default_value'     => array( 'en' ),
+						'allow_null'        => 0,
+						'multiple'          => 0,
+						'ui'                => 0,
+						'return_format'     => 'value',
+						'ajax'              => 0,
+						'placeholder'       => __( 'Choose a language', 'coop-library-framework' ),
 					),
 					array(
 						'key'               => 'field_5e56ed1ee2c88',

--- a/includes/functions/metadata.php
+++ b/includes/functions/metadata.php
@@ -472,7 +472,6 @@ function register_fields() {
 						'ui_on_text'        => '',
 						'ui_off_text'       => '',
 					),
-					// TODO: Convert existing authors.
 					array(
 						'key'               => 'field_5e56ed9c93657',
 						'label'             => __( 'Authors', 'coop-library-framework' ),
@@ -513,7 +512,6 @@ function register_fields() {
 							),
 						),
 					),
-					// TODO: Convert existing editors.
 					array(
 						'key'               => 'field_5e56ee4309400',
 						'label'             => __( 'Editors', 'coop-library-framework' ),
@@ -554,7 +552,6 @@ function register_fields() {
 							),
 						),
 					),
-					// TODO: Convert existing translators.
 					array(
 						'key'               => 'field_5e56ee6209402',
 						'label'             => __( 'Translators', 'coop-library-framework' ),
@@ -1090,7 +1087,6 @@ function register_fields() {
 						'layout'            => 'row',
 						'button_label'      => __( 'Add perma.cc link', 'coop-library-framework' ),
 						'sub_fields'        => array(
-							// TODO: Add validation and convert existing.
 							array(
 								'key'               => 'field_5e57062fee32a',
 								'label'             => __( 'Perma.cc link', 'coop-library-framework' ),
@@ -1135,7 +1131,6 @@ function register_fields() {
 						'layout'            => 'row',
 						'button_label'      => __( 'Add Internet Archive link', 'coop-library-framework' ),
 						'sub_fields'        => array(
-							// TODO: Add validation and convert existing.
 							array(
 								'key'               => 'field_5e57065fee32c',
 								'label'             => __( 'Internet Archive link', 'coop-library-framework' ),
@@ -1180,7 +1175,6 @@ function register_fields() {
 				'key'                   => 'group_5e570377058dd',
 				'title'                 => __( 'Catalog Codes', 'coop-library-framework' ),
 				'fields'                => array(
-					// TODO: Add validation.
 					array(
 						'key'               => 'field_5e5706d2de4dc',
 						'label'             => 'DOI',
@@ -1200,7 +1194,6 @@ function register_fields() {
 						'append'            => '',
 						'maxlength'         => '',
 					),
-					// TODO: Add validation.
 					array(
 						'key'               => 'field_5e5706ebde4dd',
 						'label'             => 'ISBN',
@@ -1220,7 +1213,6 @@ function register_fields() {
 						'append'            => '',
 						'maxlength'         => '',
 					),
-					// TODO: Add validation.
 					array(
 						'key'               => 'field_5e57070ade4de',
 						'label'             => 'ISSN',


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

This pull request moves resource language into a metadata field, making resources no longer translatable through Polylang. This necessitates migrating that data using the included script.

## Steps to test

1. Check out this branch.
2. Run the [language conversion](https://github.com/platform-coop-toolkit/coop-library-framework/blob/add/language-field/bin/README.md#convert-resource-language-from-polylang-to-advanced-custom-fields) script.

**Expected behavior:** Verify that all resources have a two-character language code saved as the `language` meta key and that it is correctly displayed in the main info block of the resource editor.

## Additional information

Not applicable.

## Related issues

Not applicable.
