### PR TITLE
feat: differentiate between resource and display language

### DIFF
--- a/includes/functions/core.php
+++ b/includes/functions/core.php
@@ -78,12 +78,16 @@ function resource_init() {
 		array(
 			'admin_cols'          => [
 				'title',
-				'language'  => [
-					'title'    => __( 'Language', 'coop-library-framework' ),
+				'resource-language'  => [
+					'title'    => __( 'Resource Language', 'coop-library-framework' ),
 					'meta_key' => 'language',
 					'function' => function() {
 						echo esc_attr( get_localized_language( get_post_meta( get_the_ID(), 'language', true ) ) );
 					},
+				],
+				'display-language'  => [
+					'title'    => __( 'Display Language', 'coop-library-framework' ),
+					'taxonomy' => 'language',
 				],
 				'format'    => [
 					'title'    => __( 'Format', 'coop-library-framework' ),


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

In order to properly display resources in all languages, synchronized copies need to be created in all languages. This PR adds a column to the dashboard to distinguish between the resource's intrinsic language (Resource Language) and the synchronized copy for display purposes (Display Language).

## Steps to test

1. Visit the Resources section on the dashboard.
2. Inspect the resource columns.

**Expected behavior:** Resources should reflect both their display language and intrinsic language.

## Additional information

Not applicable.

## Related issues

Not applicable.
