### PR TITLE
fix: make sub fields required to prevent empty input (resolves #310)

### DIFF
--- a/includes/functions/metadata.php
+++ b/includes/functions/metadata.php
@@ -517,7 +517,7 @@ function register_fields() {
 								'name'              => 'author',
 								'type'              => 'text',
 								'instructions'      => '',
-								'required'          => 0,
+								'required'          => 1,
 								'conditional_logic' => 0,
 								'wrapper'           => array(
 									'width' => '',
@@ -557,7 +557,7 @@ function register_fields() {
 								'name'              => 'editor',
 								'type'              => 'text',
 								'instructions'      => '',
-								'required'          => 0,
+								'required'          => 1,
 								'conditional_logic' => 0,
 								'wrapper'           => array(
 									'width' => '',
@@ -597,7 +597,7 @@ function register_fields() {
 								'name'              => 'translator',
 								'type'              => 'text',
 								'instructions'      => '',
-								'required'          => 0,
+								'required'          => 1,
 								'conditional_logic' => 0,
 								'wrapper'           => array(
 									'width' => '',


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

This addresses #310 by making sub fields of repeaters required fields. This will prevent users from saving repeaters with blank fields.

## Steps to test

1. Add a blank sub field to any repeater (author, editor, translator, Perma.cc link, Internet Archive link).
2. Save the resource.

**Expected behavior:** User is informed that the sub field is required. Removing the sub field allows them to save.

## Additional information

Not applicable.

## Related issues

- Resolves #310.